### PR TITLE
[JCG-916] Supabase RLS 보안 이슈 수정 및 환경변수 클라이언트 노출 방지

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ yarn install
 `.env.local` 파일을 생성하고 다음 변수들을 설정하세요:
 
 ```env
-# Supabase
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+# Supabase (서버 전용 - NEXT_PUBLIC_ 접두사 사용하지 않음)
+SUPABASE_URL=your_supabase_url
+SUPABASE_ANON_KEY=your_supabase_anon_key
 
 # Email notifications (선택사항)
 EMAIL_API_KEY=your_email_api_key

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -2,10 +2,9 @@
 import { createClient } from "@supabase/supabase-js";
 
 // 환경 변수에서 Supabase URL과 익명 키를 가져옴
-// ! 연산자는 TypeScript에게 이 값들이 반드시 존재한다고 알려줌
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!; // process : Node.js 애플리케이션이 실행될 때 자동으로 생성되는 전역 객체
-// 프로세스의 정보를 조회하고 제어할 수 있는 다양한 속성과 메서드를 제공
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+// 서버 사이드에서만 사용되므로 NEXT_PUBLIC_ 접두사 불필요 (클라이언트 노출 방지)
+const supabaseUrl = process.env.SUPABASE_URL!;
+const supabaseKey = process.env.SUPABASE_ANON_KEY!;
 
 // Supabase 클라이언트 인스턴스 생성 및 export
 // 이 인스턴스를 통해 데이터베이스와 상호작용

--- a/sql/create_post_downloads_table.sql
+++ b/sql/create_post_downloads_table.sql
@@ -3,3 +3,15 @@ CREATE TABLE
     post_slug TEXT PRIMARY KEY,
     downloads BIGINT DEFAULT 0
   );
+
+-- RLS (Row Level Security) 정책 설정
+ALTER TABLE post_downloads ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access on post_downloads" ON post_downloads
+    FOR SELECT USING (true);
+
+CREATE POLICY "Allow public insert access on post_downloads" ON post_downloads
+    FOR INSERT WITH CHECK (true);
+
+CREATE POLICY "Allow public update access on post_downloads" ON post_downloads
+    FOR UPDATE USING (true);

--- a/sql/enable_rls_all_tables.sql
+++ b/sql/enable_rls_all_tables.sql
@@ -1,0 +1,36 @@
+-- RLS 미설정 테이블에 Row Level Security 활성화
+-- Supabase Security Advisor 경고 해결용 마이그레이션
+-- 실행: Supabase Dashboard > SQL Editor에서 실행
+
+-- ============================================================
+-- 1. visitors 테이블 RLS 활성화
+-- ============================================================
+ALTER TABLE visitors ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access on visitors" ON visitors
+    FOR SELECT USING (true);
+
+CREATE POLICY "Allow public insert access on visitors" ON visitors
+    FOR INSERT WITH CHECK (true);
+
+CREATE POLICY "Allow public update access on visitors" ON visitors
+    FOR UPDATE USING (true);
+
+-- ============================================================
+-- 2. post_downloads 테이블 RLS 활성화
+-- ============================================================
+ALTER TABLE post_downloads ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access on post_downloads" ON post_downloads
+    FOR SELECT USING (true);
+
+CREATE POLICY "Allow public insert access on post_downloads" ON post_downloads
+    FOR INSERT WITH CHECK (true);
+
+CREATE POLICY "Allow public update access on post_downloads" ON post_downloads
+    FOR UPDATE USING (true);
+
+-- ============================================================
+-- 확인
+-- ============================================================
+SELECT 'RLS가 visitors, post_downloads 테이블에 성공적으로 활성화되었습니다.' as message;


### PR DESCRIPTION
## 개요

Supabase Security Advisor에서 감지된 두 가지 보안 이슈를 수정합니다.

1. `visitors`, `post_downloads` 테이블에 Row Level Security(RLS)가 비활성화되어 PostgREST를 통해 공개 접근이 가능했던 문제
2. Supabase 클라이언트 초기화 시 `NEXT_PUBLIC_` 접두사 환경변수를 사용하여 URL과 ANON KEY가 브라우저에 노출될 수 있었던 문제

## 변경 사항

- **lib/supabase.ts**: `NEXT_PUBLIC_SUPABASE_URL` → `SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` → `SUPABASE_ANON_KEY`로 변경. 해당 클라이언트는 서버 사이드에서만 사용되므로 `NEXT_PUBLIC_` 접두사 제거로 클라이언트 번들 노출 차단
- **sql/enable_rls_all_tables.sql**: `visitors`, `post_downloads` 테이블 RLS 활성화 및 공개 읽기/쓰기/수정 정책 추가 마이그레이션 SQL 생성
- **sql/create_post_downloads_table.sql**: 테이블 생성 SQL에 RLS 활성화 및 정책 추가 (신규 환경에서 테이블 생성 시 RLS가 함께 적용되도록)
- **README.md**: 환경변수 가이드를 `SUPABASE_URL`, `SUPABASE_ANON_KEY`로 업데이트하고 서버 전용임을 명시

## 테스트 계획

### Supabase 보안 어드바이저
- Supabase Dashboard > [Security Advisor](https://supabase.com/dashboard/project/dftysrslrcqpavsxfmry/advisors/security) 접속 후 `rls_disabled_in_public` 경고 해소 확인

### 블로그 방문자 수 및 다운로드 카운트 기능 동작 확인
- https://oooo12.com 메인 페이지 접속 후 방문자 수(`visitors` 테이블) 정상 증가 확인
- https://oooo12.com/jcheogi 접속 후 정처기 자료 다운로드 버튼 클릭 시 `post_downloads` 카운트 정상 증가 확인

### 환경변수 노출 확인
- 프로덕션 배포 후 브라우저 콘솔 또는 페이지 소스에서 `SUPABASE_URL`, `SUPABASE_ANON_KEY` 값이 노출되지 않는지 확인 (`window.__NEXT_DATA__` 등)

## 관련 이슈

Resolves JCG-916