### PR TITLE
[JCG-2118] 중복 정처기 이론 글 리다이렉트

### DIFF
--- a/app/components/Featured.tsx
+++ b/app/components/Featured.tsx
@@ -10,7 +10,7 @@ export async function FeaturedPost({
 }) {
   const { locale } = await params;
   const featuredMetadata = await getPost(
-    "korean-information-processing-engineer-practical-exam-strategy",
+    "jeongcheogi-practical-theory-summary-pdf",
     locale
   );
   const t = await getTranslations("home");

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getPosts } from "@/lib/utils";
+import { isRedirectedPostSlug } from "@/lib/post-redirects";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // 정적 페이지들
@@ -37,9 +38,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  // 리다이렉트하는 slug들을 제외
-  const redirectedSlugs: string[] = [];
-
   // 블로그 포스트들을 가져와서 sitemap에 추가
   const koPostsData = await getPosts("ko");
   const enPostsData = await getPosts("en");
@@ -48,7 +46,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // 한국어 포스트들 처리 (리다이렉트하는 slug 제외)
   for (const post of koPostsData.posts) {
-    if (!redirectedSlugs.includes(post.slug)) {
+    if (!isRedirectedPostSlug(post.slug)) {
       blogPosts.push({
         url: `https://www.kimjaahyun.com/ko/blog/${post.slug}`,
         lastModified: new Date(post.metadata.lastModifiedAt),
@@ -63,7 +61,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // 영어 포스트들 처리 (리다이렉트하는 slug 제외)
   for (const post of enPostsData.posts) {
-    if (!redirectedSlugs.includes(post.slug)) {
+    if (!isRedirectedPostSlug(post.slug)) {
       blogPosts.push({
         url: `https://www.kimjaahyun.com/en/blog/${post.slug}`,
         lastModified: new Date(post.metadata.lastModifiedAt),

--- a/contents/jeongcheogi-pass-review/en.mdx
+++ b/contents/jeongcheogi-pass-review/en.mdx
@@ -210,7 +210,7 @@ But in fact, there were many false positives in the book.
 
 ## Peace (平安)
 
-The minimal theory study scope to get 60 points is written on the [Information Processing Engineer Practical Study Method [Theory Part] 👺 | 2025 2nd Practical Theory Problem Prediction Based on Past Exams](/ko/blog/korean-information-processing-engineer-practical-exam-strategy) page.
+The minimal theory study scope to get 60 points is written on the [Information Processing Engineer Practical Study Method [Theory Part] 👺 | 2025 2nd Practical Theory Problem Prediction Based on Past Exams](https://jeongcheogi.edugamja.com/theory/theory-expected-questions) page.
 
 And based on this scope, matching terms and keywords from past exam problems is summarized in [Information Processing Engineer Practical Theory Summary PDF Download 2025 2nd Prediction Ultra-Compressed Cramming](/ko/blog/jeongcheogi-practical-theory-summary-pdf).
 

--- a/contents/jeongcheogi-pass-review/ko.mdx
+++ b/contents/jeongcheogi-pass-review/ko.mdx
@@ -228,7 +228,7 @@ AI덕에 공부를 재밌게 할 수 있었지만, 여전히 이론 공부양이
 
 ## 평안(平安)
 
-60점을 얻기 위한 최소 이론 공부 범위를 적어놓은 것이 [정처기 실기 공부법 [이론편] 👺 | 기출 기반 2025년 2회 실기 이론 문제 예상](/ko/blog/korean-information-processing-engineer-practical-exam-strategy) 페이지이다.
+60점을 얻기 위한 최소 이론 공부 범위를 적어놓은 것이 [정처기 실기 공부법 [이론편] 👺 | 기출 기반 2025년 2회 실기 이론 문제 예상](https://jeongcheogi.edugamja.com/theory/theory-expected-questions) 페이지이다.
 
 그리고 이 범위를 기반으로 용어와 기출문제에 나온 키워드를 매칭하여 요약한 것이 [정처기 실기 요약 이론 pdf 다운 2025년 2회 예상 초압축 벼락치기용](/ko/blog/jeongcheogi-practical-theory-summary-pdf) 이다.
 

--- a/contents/jeongcheogi-practical-exam-review-2025-2/en.mdx
+++ b/contents/jeongcheogi-practical-exam-review-2025-2/en.mdx
@@ -48,7 +48,7 @@ The main features of the 2nd round of the 2025 practical exam are as follows:
 - Link to the ultra-compressed summary PDF: [Information Processing Engineer Practical Exam Summary Theory PDF Download 2025 2nd Expected Ultra-Compressed Cramming
   ](https://www.kimjaahyun.com/ko/blog/jeongcheogi-practical-theory-summary-pdf)
 - Link to the expected theory range: [How to Study for the Information Processing Engineer Practical Exam [Theory] 👺 | 2025 2nd Practical Exam Theory Question Prediction Based on Past Questions
-  ](https://www.kimjaahyun.com/ko/blog/korean-information-processing-engineer-practical-exam-strategy)
+  ](https://jeongcheogi.edugamja.com/theory/theory-expected-questions)
 
 | Question                                                                    | Answer                                   | Subject      | Hit |
 | :-------------------------------------------------------------------------- | :--------------------------------------- | :----------- | :-- |

--- a/contents/jeongcheogi-practical-exam-review-2025-2/ko.mdx
+++ b/contents/jeongcheogi-practical-exam-review-2025-2/ko.mdx
@@ -43,7 +43,7 @@ export const metadata = {
 - 정처기 초압축 요약 PDF 링크 : [정처기 실기 요약 이론 PDF 다운 2025년 2회 예상 초압축 벼락치기용
   ](https://www.kimjaahyun.com/ko/blog/jeongcheogi-practical-theory-summary-pdf)
 - 정처기 이론 예상 범위 링크 : [정처기 실기 공부법 [이론편] 👺 | 기출 기반 2025년 2회 실기 이론 문제 예상
-  ](https://www.kimjaahyun.com/ko/blog/korean-information-processing-engineer-practical-exam-strategy)
+  ](https://jeongcheogi.edugamja.com/theory/theory-expected-questions)
 
 | 문제                                                      | 정답                    | 과목        | 적중 |
 | :-------------------------------------------------------- | :---------------------- | :---------- | :--- |

--- a/contents/jeongcheogi-practical-theory-summary-pdf/en.mdx
+++ b/contents/jeongcheogi-practical-theory-summary-pdf/en.mdx
@@ -90,7 +90,7 @@ The PDF includes memorization tips. You can also find each tip on this blog.
 
 This ultra-condensed theory summary PDF for the practical exam was created to meet the minimum required score from theory questions (7 correct answers) for passing.
 
-For more details, please refer to the [Engineer Information Processing Practical Exam Study Method [Theory] 👺 | Predicting Theory Questions for the 2nd 2025 Exam Based on Past Papers](/en/blog/korean-information-processing-engineer-practical-exam-strategy) page.
+For more details, please refer to the [Engineer Information Processing Practical Exam Study Method [Theory] 👺 | Predicting Theory Questions for the 2nd 2025 Exam Based on Past Papers](https://jeongcheogi.edugamja.com/theory/theory-expected-questions) page.
 
 <DownloadButton
   slug="jeongcheogi-practical-theory-summary-pdf"

--- a/contents/jeongcheogi-practical-theory-summary-pdf/ko.mdx
+++ b/contents/jeongcheogi-practical-theory-summary-pdf/ko.mdx
@@ -119,17 +119,17 @@ PDF에는 암기법을 포함하고 있습니다. 각 암기법은 이 블로그
 | 보안        | 1개    | 0개              |
 | 총          | 11개   |
 
-자세한 내용은 [정처기 실기 공부법 [이론편] 👺 | 기출 기반 2025년 2회 실기 이론 문제 예상](/ko/blog/korean-information-processing-engineer-practical-exam-strategy) 페이지를 참고해주세요.
+자세한 내용은 [정처기 실기 공부법 [이론편] 👺 | 기출 기반 2025년 2회 실기 이론 문제 예상](https://jeongcheogi.edugamja.com/theory/theory-expected-questions) 페이지를 참고해주세요.
 
 ## 정보처리기사 실기 대비 문제
 
 실기 대비 문제는 각 범위에 대한 설명 블로그 포스팅 하단에 있습니다.
 
-[정처기 실기 공부법 [이론편] 👺 | 기출 기반 2025년 2회 실기 이론 문제 예상](/ko/blog/korean-information-processing-engineer-practical-exam-strategy) 페이지의 링크를 활용하세요.
+[정처기 실기 공부법 [이론편] 👺 | 기출 기반 2025년 2회 실기 이론 문제 예상](https://jeongcheogi.edugamja.com/theory/theory-expected-questions) 페이지의 링크를 활용하세요.
 
 ## 이론 문제를 더 확실하게 준비하는 방법
 
-[정처기 실기 공부법 [이론편] 👺 - 2025년 2회 정처기 실기 이론 출제 문제 예측](/ko/blog/korean-information-processing-engineer-practical-exam-strategy#2025년-2회-정처기-실기-이론-출제-문제-예측) 링크로 들어가면 🤔 : 20% 출제확률 범위가 있습니다.
+[정처기 실기 공부법 [이론편] 👺 - 2025년 2회 정처기 실기 이론 출제 문제 예측](https://jeongcheogi.edugamja.com/theory/theory-expected-questions) 링크로 들어가면 🤔 : 20% 출제확률 범위가 있습니다.
 
 해당 범위까지 완벽하게 마스터해보세요.
 

--- a/lib/post-redirects.ts
+++ b/lib/post-redirects.ts
@@ -1,0 +1,21 @@
+export const redirectedPostSlugs = [
+  "korean-information-processing-engineer-practical-exam-strategy",
+] as const;
+
+export const theoryExpectedQuestionsUrl =
+  "https://jeongcheogi.edugamja.com/theory/theory-expected-questions";
+
+export const postRedirects = redirectedPostSlugs.flatMap((slug) => [
+  {
+    source: `/ko/blog/${slug}`,
+    destination: theoryExpectedQuestionsUrl,
+  },
+  {
+    source: `/en/blog/${slug}`,
+    destination: theoryExpectedQuestionsUrl,
+  },
+]);
+
+export function isRedirectedPostSlug(slug: string): boolean {
+  return (redirectedPostSlugs as readonly string[]).includes(slug);
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import { supabase } from "./supabase";
 import { Comment, CommentFormData } from "./types";
+import { isRedirectedPostSlug } from "./post-redirects";
 
 interface ReviewRating {
   "@type": "Rating";
@@ -193,7 +194,10 @@ export async function getPost(slug: string, locale: string): Promise<Post | null
 
 export function getPostSlugs(): string[] {
   const postsDirectory = path.resolve(process.cwd(), "contents");
-  return fs.readdirSync(postsDirectory).filter((file) => file !== ".DS_Store");
+  return fs
+    .readdirSync(postsDirectory)
+    .filter((file) => file !== ".DS_Store")
+    .filter((slug) => !isRedirectedPostSlug(slug));
 }
 
 export async function getPosts(

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,12 +3,20 @@ import type { NextConfig } from "next";
 import createMDX from "@next/mdx";
 // 중괄호가 없으면: "이 모듈의 기본(default) export를 가져와줘"
 import createNextIntlPlugin from "next-intl/plugin";
+import { postRedirects } from "./lib/post-redirects";
 
 const nextConfig: NextConfig = {
   /* config options here */
   // Configure `pageExtensions` to include markdown and MDX files
   pageExtensions: ["md", "mdx", "ts", "tsx"],
   // Optionally, add any other Next.js config below
+  async redirects() {
+    return postRedirects.map(({ source, destination }) => ({
+      source,
+      destination,
+      statusCode: 301,
+    }));
+  },
 };
 
 const withNextIntl = createNextIntlPlugin();


### PR DESCRIPTION
## 릴리스 개요
이번 릴리스에는 kimjaahyun에 남아 있던 정처기 이론 전략 글의 중복 노출 정리 작업 1건이 포함됩니다.

## 포함된 이슈
- [JCG-2118] 남은 kimjaahyun 중복글 정리 — 기존 정처기 이론 전략 글을 edugamja 대응 페이지로 301 리다이렉트하고, 내부 링크와 sitemap 노출을 정리했습니다.

## 이슈 외 변경
- 없음

## 테스트 계획
### 타입 검사
- `yarn tsc --noEmit`로 TypeScript 타입 검사를 통과했습니다.

### 리다이렉트
- `http://127.0.0.1:3123/ko/blog/korean-information-processing-engineer-practical-exam-strategy`에서 `301 Moved Permanently`와 `Location: https://jeongcheogi.edugamja.com/theory/theory-expected-questions`를 확인했습니다.
- `http://127.0.0.1:3123/en/blog/korean-information-processing-engineer-practical-exam-strategy`에서 `301 Moved Permanently`와 `Location: https://jeongcheogi.edugamja.com/theory/theory-expected-questions`를 확인했습니다.
- 배포 후 확인 URL: https://www.kimjaahyun.com/ko/blog/korean-information-processing-engineer-practical-exam-strategy
- 배포 후 확인 URL: https://www.kimjaahyun.com/en/blog/korean-information-processing-engineer-practical-exam-strategy

### sitemap
- `http://127.0.0.1:3123/sitemap.xml`에서 `korean-information-processing-engineer-practical-exam-strategy`와 `theory-expected-questions`가 노출되지 않는 것을 확인했습니다.
- 배포 후 확인 URL: https://www.kimjaahyun.com/sitemap.xml

## 관련 이슈
Resolves JCG-2118