### PR TITLE
[JCG-2115] 2025년 2회 후기 URL 영구 리다이렉트 적용

### DIFF
--- a/app/components/Banner.tsx
+++ b/app/components/Banner.tsx
@@ -60,7 +60,7 @@ export default function Banner() {
           </CarouselItem>
           {/* <CarouselItem className="basis-1/2">
             <Link
-              href="https://www.kimjaahyun.com/ko/blog/jeongcheogi-practical-exam-review-2025-2"
+              href="https://jeongcheogi.edugamja.com/past-exam/2025/2025-2-review"
               target="_blank"
             >
               <div className="p-1">

--- a/contents/jeongcheogi-difficulty-theory/ko.mdx
+++ b/contents/jeongcheogi-difficulty-theory/ko.mdx
@@ -179,7 +179,7 @@ EMPLOYEE 테이블
 ## 추천 포스팅
 
 <TooltipLink
-  href="/ko/blog/jeongcheogi-practical-exam-review-2025-2"
+  href="https://jeongcheogi.edugamja.com/past-exam/2025/2025-2-review"
   text="2025년 2회 정처기 실기 후기"
 />
 <br />

--- a/lib/post-redirects.ts
+++ b/lib/post-redirects.ts
@@ -1,20 +1,27 @@
-export const redirectedPostSlugs = [
-  "korean-information-processing-engineer-practical-exam-strategy",
-] as const;
+export const redirectedPostTargets = {
+  "korean-information-processing-engineer-practical-exam-strategy":
+    "https://jeongcheogi.edugamja.com/theory/theory-expected-questions",
+  "jeongcheogi-practical-exam-review-2025-2":
+    "https://jeongcheogi.edugamja.com/past-exam/2025/2025-2-review",
+} as const;
 
-export const theoryExpectedQuestionsUrl =
-  "https://jeongcheogi.edugamja.com/theory/theory-expected-questions";
+export const redirectedPostSlugs = Object.keys(redirectedPostTargets);
 
-export const postRedirects = redirectedPostSlugs.flatMap((slug) => [
-  {
-    source: `/ko/blog/${slug}`,
-    destination: theoryExpectedQuestionsUrl,
-  },
-  {
-    source: `/en/blog/${slug}`,
-    destination: theoryExpectedQuestionsUrl,
-  },
-]);
+export const postRedirects = redirectedPostSlugs.flatMap((slug) => {
+  const destination =
+    redirectedPostTargets[slug as keyof typeof redirectedPostTargets];
+
+  return [
+    {
+      source: `/ko/blog/${slug}`,
+      destination,
+    },
+    {
+      source: `/en/blog/${slug}`,
+      destination,
+    },
+  ];
+});
 
 export function isRedirectedPostSlug(slug: string): boolean {
   return (redirectedPostSlugs as readonly string[]).includes(slug);


### PR DESCRIPTION
## 개요
2025년 2회 정보처리기사 실기 후기 글의 canonical 위치를 jcg-gamja로 옮긴 뒤, 기존 blog-next URL이 새 canonical 페이지로 301 영구 이동되도록 정리합니다.

## 변경 사항
- `lib/post-redirects.ts`: 2025년 2회 후기 slug의 한국어/영어 블로그 URL을 `https://jeongcheogi.edugamja.com/past-exam/2025/2025-2-review`로 301 리다이렉트하도록 추가
- `contents/jeongcheogi-difficulty-theory/ko.mdx`: 추천 포스팅 링크를 새 canonical URL로 변경
- `app/components/Banner.tsx`: 배너 참조 URL을 새 canonical URL로 변경

## 테스트 계획
### 타입 체크
- `yarn tsc --noEmit` 통과

### 리다이렉트
- `http://127.0.0.1:3123/ko/blog/jeongcheogi-practical-exam-review-2025-2`가 `https://jeongcheogi.edugamja.com/past-exam/2025/2025-2-review`로 301 응답하는 것 확인
- `http://127.0.0.1:3123/en/blog/jeongcheogi-practical-exam-review-2025-2`가 `https://jeongcheogi.edugamja.com/past-exam/2025/2025-2-review`로 301 응답하는 것 확인

### 사이트맵
- `http://127.0.0.1:3123/sitemap.xml`에 `jeongcheogi-practical-exam-review-2025-2` slug가 포함되지 않는 것 확인

## 관련 이슈
Resolves JCG-2115