### PR TITLE
[JCG-2506] 정처기 난이도 이론 글 리다이렉트 추가

### DIFF
--- a/lib/post-redirects.ts
+++ b/lib/post-redirects.ts
@@ -3,6 +3,8 @@ export const redirectedPostTargets = {
     "https://jeongcheogi.edugamja.com/theory/theory-expected-questions",
   "jeongcheogi-practical-exam-review-2025-2":
     "https://jeongcheogi.edugamja.com/past-exam/2025/2025-2-review",
+  "jeongcheogi-difficulty-theory":
+    "https://jeongcheogi.edugamja.com/theory/jeongcheogi-difficulty-theory",
 } as const;
 
 export const redirectedPostSlugs = Object.keys(redirectedPostTargets);


### PR DESCRIPTION
## 릴리스 개요
정처기 난이도 이론 글의 jcg-gamja 편입에 맞춰 blog-next의 기존 블로그 URL을 새 jcg-gamja 이론 페이지로 301 리다이렉트합니다. 포함 이슈는 1건입니다.

## 포함된 이슈
- [JCG-2506] 난이도 이론 글 jcg-gamja 편입 및 코딩문제 난이도 글 추가 - `lib/post-redirects.ts`에 `jeongcheogi-difficulty-theory` slug의 `/ko`·`/en` 블로그 리다이렉트를 추가했습니다.

## 이슈 외 변경
- 없음

## 테스트 계획
### 타입 체크
- `yarn tsc --noEmit` 통과

### 리다이렉트 데이터
- `lib/post-redirects.ts` import 검증으로 `/ko/blog/jeongcheogi-difficulty-theory`와 `/en/blog/jeongcheogi-difficulty-theory`가 `https://jeongcheogi.edugamja.com/theory/jeongcheogi-difficulty-theory`를 destination으로 생성하는지 확인

### 콘텐츠 경로
- `contents/jeongcheogi-difficulty-theory/ko.mdx`와 `contents/jeongcheogi-difficulty-theory/en.mdx` 존재 확인
- `https://www.kimjaahyun.com/ko/blog/jeongcheogi-difficulty-theory`
- `https://www.kimjaahyun.com/en/blog/jeongcheogi-difficulty-theory`

## 관련 이슈
Resolves JCG-2506
